### PR TITLE
Use npm specifiers to import stripe

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a collection of samples for Deno applications which use `stripe-node`.
 
-**Note that these require Deno v1.16 or greater.**
+**Note that these require Deno v1.28 or greater.**
 
 The following samples are available: 
 

--- a/checkout-integration/README.md
+++ b/checkout-integration/README.md
@@ -2,7 +2,7 @@
 This is an example Checkout integration using Deno. This is based on 
 https://stripe.com/docs/payments/accept-a-payment?integration=checkout.
 
-**Note that this requires Deno v1.16 or greater.**
+**Note that this requires Deno v1.28 or greater.**
 
 ## Setup
 

--- a/checkout-integration/main.js
+++ b/checkout-integration/main.js
@@ -1,7 +1,6 @@
 import { serveListener } from "https://deno.land/std@0.116.0/http/server.ts";
 
-// esm.sh is used to compile stripe-node to be compatible with ES modules.
-import Stripe from "https://esm.sh/stripe?target=deno";
+import Stripe from "npm:stripe@^11.16";
 
 const stripe = Stripe(Deno.env.get("STRIPE_API_KEY"), {
   // This is needed to use the Fetch API rather than relying on the Node http

--- a/webhook-signing/README.md
+++ b/webhook-signing/README.md
@@ -1,7 +1,7 @@
 # Webhook Signing
 This is an example of receiving and verifying a Webhook using Deno.
 
-**Note that this requires Deno v1.16 or greater.**
+**Note that this requires Deno v1.28 or greater.**
 
 ## Setup
 

--- a/webhook-signing/main.js
+++ b/webhook-signing/main.js
@@ -1,15 +1,8 @@
 import { serveListener } from "https://deno.land/std@0.116.0/http/server.ts";
 
-// esm.sh is used to compile stripe-node to be compatible with ES modules.
-import Stripe from "https://esm.sh/stripe?target=deno";
+import Stripe from "npm:stripe@^11.16";
 
-const stripe = Stripe(Deno.env.get("STRIPE_API_KEY"), {
-  // This is needed to use the Fetch API rather than relying on the Node http
-  // package.
-  httpClient: Stripe.createFetchHttpClient(),
-});
-// This is needed in order to use the Web Crypto API in Deno.
-const cryptoProvider = Stripe.createSubtleCryptoProvider();
+const stripe = Stripe(Deno.env.get("STRIPE_API_KEY"));
 
 const server = Deno.listen({ port: 8080 });
 console.log(`HTTP webserver running.  Access it at:  http://localhost:8080/`);
@@ -27,8 +20,7 @@ async function handler(request) {
       body,
       signature,
       Deno.env.get("STRIPE_WEBHOOK_SIGNING_SECRET"),
-      undefined,
-      cryptoProvider
+      undefined
     );
   } catch (err) {
     return new Response(err.message, { status: 400 });


### PR DESCRIPTION
We added a Deno target in [stripe-node v11.16.0](https://github.com/stripe/stripe-node/releases/tag/v11.16.0) to allow the right entry point file to be used by Deno users who import stripe using npm specifiers.